### PR TITLE
feat(conditions): Simplify conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,8 @@
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon
+
 
 # Thumbnails
 ._*
@@ -93,6 +94,10 @@ $RECYCLE.BIN/
 !.vscode/launch.json
 !.vscode/extensions.json
 !.vscode/*.code-snippets
+
+### IntelliJ ###
+*.iml
+.idea
 
 # Local History for Visual Studio Code
 .history/

--- a/templates/clusterRole.cue
+++ b/templates/clusterRole.cue
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"strings"
 	rbacv1 "k8s.io/api/rbac/v1"
 	timoniv1 "timoni.sh/core/v1alpha1"
 
@@ -21,7 +22,7 @@ import (
 
 	#meta: timoniv1.#MetaComponent & {
 		#Meta:      #config.metadata
-		#Component: #component
+		#Component: strings.ToLower(#component)
 	}
 
 	apiVersion: "rbac.authorization.k8s.io/v1"
@@ -58,323 +59,362 @@ import (
 	if #meta.annotations != _|_ {
 		metadata: annotations: #meta.annotations
 	}
+}
 
-	if #component == "controller" {
-		// Cluster View
-		if #role == "cluster-view" {
-			rules: [{
-				apiGroups: ["cert-manager.io"]
-				resources: ["clusterissuers"]
-				verbs: ["get", "list", "watch"]
-			}]
-		}
-
-		// View
-		if #role == "view" {
-			rules: [{
-				apiGroups: ["cert-manager.io"]
-				resources: ["certificates", "certificaterequests", "issuers"]
-				verbs: ["get", "list", "watch"]
-			}, {
-				apiGroups: ["acme.cert-manager.io"]
-				resources: ["challenges", "orders"]
-				verbs: ["get", "list", "watch"]
-			}]
-		}
-
-		// Edit
-		if #role == "edit" {
-			rules: [{
-				apiGroups: ["cert-manager.io"]
-				resources: ["certificates", "certificaterequests", "issuers"]
-				verbs: ["create", "delete", "deletecollection", "patch", "update"]
-			}, {
-				apiGroups: ["cert-manager.io"]
-				resources: ["certificates/status"]
-				verbs: ["update"]
-			}, {
-				apiGroups: ["acme.cert-manager.io"]
-				resources: ["challenges", "orders"]
-				verbs: ["create", "delete", "deletecollection", "patch", "update"]
-			}]
-		}
-
-		// Controller Issuers
-		if #role == "issuers" {
-			rules: [{
-				apiGroups: ["cert-manager.io"]
-				resources: ["issuers", "issuers/status"]
-				verbs: ["update", "patch"]
-			}, {
-				apiGroups: ["cert-manager.io"]
-				resources: ["issuers"]
-				verbs: ["get", "list", "watch"]
-			}, {
-				apiGroups: [""]
-				resources: ["secrets"]
-				verbs: ["get", "list", "watch", "create", "update", "delete"]
-			}, {
-				apiGroups: [""]
-				resources: ["events"]
-				verbs: ["create", "patch"]
-			}]
-		}
-
-		// Controller ClusterIssuers
-		if #role == "clusterissuers" {
-			rules: [{
-				apiGroups: ["cert-manager.io"]
-				resources: ["clusterissuers", "clusterissuers/status"]
-				verbs: ["update", "patch"]
-			}, {
-				apiGroups: ["cert-manager.io"]
-				resources: ["clusterissuers"]
-				verbs: ["get", "list", "watch"]
-			}, {
-				apiGroups: [""]
-				resources: ["secrets"]
-				verbs: ["get", "list", "watch", "create", "update", "delete"]
-			}, {
-				apiGroups: [""]
-				resources: ["events"]
-				verbs: ["create", "patch"]
-			}]
-		}
-
-		// Controller Certificates
-		if #role == "certificates" {
-			rules: [{
-				apiGroups: ["cert-manager.io"]
-				resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
-				verbs: ["update", "patch"]
-			}, {
-				apiGroups: ["cert-manager.io"]
-				resources: ["certificates", "certificaterequests", "clusterissuers", "issuers"]
-				verbs: ["get", "list", "watch"]
-			}, {
-				// We require these rules to support users with the OwnerReferencesPermissionEnforcement
-				// admission controller enabled:
-				// https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
-				apiGroups: ["cert-manager.io"]
-				resources: ["certificates/finalizers", "certificaterequests/finalizers"]
-				verbs: ["update"]
-			}, {
-				apiGroups: ["acme.cert-manager.io"]
-				resources: ["orders"]
-				verbs: ["create", "delete", "get", "list", "watch"]
-			}, {
-				apiGroups: [""]
-				resources: ["secrets"]
-				verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
-			}, {
-				apiGroups: [""]
-				resources: ["events"]
-				verbs: ["create", "patch"]
-			}]
-		}
-
-		// Controller Orders
-		if #role == "orders" {
-			rules: [{
-				apiGroups: ["acme.cert-manager.io"]
-				resources: ["orders", "orders/status"]
-				verbs: ["update", "patch"]
-			}, {
-				apiGroups: ["acme.cert-manager.io"]
-				resources: ["orders", "challenges"]
-				verbs: ["get", "list", "watch"]
-			}, {
-				apiGroups: ["cert-manager.io"]
-				resources: ["clusterissuers", "issuers"]
-				verbs: ["get", "list", "watch"]
-			}, {
-				apiGroups: ["acme.cert-manager.io"]
-				resources: ["challenges"]
-				verbs: ["create", "delete"]
-			}, {
-				// We require these rules to support users with the OwnerReferencesPermissionEnforcement
-				// admission controller enabled:
-				// https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
-				apiGroups: ["acme.cert-manager.io"]
-				resources: ["orders/finalizers"]
-				verbs: ["update"]
-			}, {
-				apiGroups: [""]
-				resources: ["secrets"]
-				verbs: ["get", "list", "watch"]
-			}, {
-				apiGroups: [""]
-				resources: ["events"]
-				verbs: ["create", "patch"]
-			}]
-		}
-
-		// Controller Challenges
-		if #role == "challenges" {
-			rules: [{
-				// Use to update challenge resource status
-				apiGroups: ["acme.cert-manager.io"]
-				resources: ["challenges", "challenges/status"]
-				verbs: ["update", "patch"]
-			}, {
-				// Used to watch challenge resources
-				apiGroups: ["acme.cert-manager.io"]
-				resources: ["challenges"]
-				verbs: ["get", "list", "watch"]
-			}, {
-				// Used to watch challenges, issuer and clusterissuer resources
-				apiGroups: ["cert-manager.io"]
-				resources: ["issuers", "clusterissuers"]
-				verbs: ["get", "list", "watch"]
-			}, {
-				// Need to be able to retrieve ACME account private key to complete challenges
-				apiGroups: [""]
-				resources: ["secrets"]
-				verbs: ["get", "list", "watch"]
-			}, {
-				// Used to create events
-				apiGroups: [""]
-				resources: ["events"]
-				verbs: ["create", "patch"]
-			}, {
-				// HTTP01 rules
-				apiGroups: [""]
-				resources: ["pods", "services"]
-				verbs: ["get", "list", "watch", "create", "delete"]
-			}, {
-				apiGroups: ["networking.k8s.io"]
-				resources: ["ingresses"]
-				verbs: ["get", "list", "watch", "create", "delete", "update"]
-			}, {
-				apiGroups: ["gateway.networking.k8s.io"]
-				resources: ["httproutes"]
-				verbs: ["get", "list", "watch", "create", "delete", "update"]
-			}, {
-				// We require the ability to specify a custom hostname when we are creating
-				// new ingress resources.
-				// See: https://github.com/openshift/origin/blob/21f191775636f9acadb44fa42beeb4f75b255532/pkg/route/apiserver/admission/ingress_admission.go#L84-L148
-				apiGroups: ["route.openshift.io"]
-				resources: ["routes/custom-host"]
-				verbs: ["create"]
-			}, {
-				// We require these rules to support users with the OwnerReferencesPermissionEnforcement
-				// admission controller enabled:
-				// https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
-				apiGroups: ["acme.cert-manager.io"]
-				resources: ["challenges/finalizers"]
-				verbs: ["update"]
-			}, {
-				// DNS01 rules (duplicated above)
-				apiGroups: [""]
-				resources: ["secrets"]
-				verbs: ["get", "list", "watch"]
-			}]
-		}
-
-		// Controller Ingress Shim
-		if #role == "ingress-shim" {
-			rules: [{
-				apiGroups: ["cert-manager.io"]
-				resources: ["certificates", "certificaterequests"]
-				verbs: ["create", "update", "delete"]
-			}, {
-				apiGroups: ["cert-manager.io"]
-				resources: ["certificates", "certificaterequests", "issuers", "clusterissuers"]
-				verbs: ["get", "list", "watch"]
-			}, {
-				apiGroups: ["networking.k8s.io"]
-				resources: ["ingresses"]
-				verbs: ["get", "list", "watch"]
-			}, {
-				// We require these rules to support users with the OwnerReferencesPermissionEnforcement
-				// admission controller enabled:
-				// https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
-				apiGroups: ["networking.k8s.io"]
-				resources: ["ingresses/finalizers"]
-				verbs: ["update"]
-			}, {
-				apiGroups: ["gateway.networking.k8s.io"]
-				resources: ["gateways", "httproutes"]
-				verbs: ["get", "list", "watch"]
-			}, {
-				apiGroups: ["gateway.networking.k8s.io"]
-				resources: ["gateways/finalizers", "httproutes/finalizers"]
-				verbs: ["update"]
-			}, {
-				apiGroups: [""]
-				resources: ["events"]
-				verbs: ["create", "patch"]
-			}]
-		}
-
-		// Approve cert-manager-io
-		if #role == "approve:cert-manager-io" {
-			rules: [{
-				apiGroups: ["cert-manager.io"]
-				resources: ["signers"]
-				verbs: ["approve"]
-				resourceNames: ["issuers.cert-manager.io/*", "clusterissuers.cert-manager.io/*"]
-			}]
-		}
-
-		// Certificate Signing Requests
-		if #role == "certificatesigningrequests" {
-			rules: [{
-				apiGroups: ["certificates.k8s.io"]
-				resources: ["certificatesigningrequests"]
-				verbs: ["get", "list", "watch", "update"]
-			}, {
-				apiGroups: ["certificates.k8s.io"]
-				resources: ["certificatesigningrequests/status"]
-				verbs: ["update", "patch"]
-			}, {
-				apiGroups: ["certificates.k8s.io"]
-				resources: ["signers"]
-				resourceNames: ["issuers.cert-manager.io/*", "clusterissuers.cert-manager.io/*"]
-				verbs: ["sign"]
-			}, {
-				apiGroups: ["authorization.k8s.io"]
-				resources: ["subjectaccessreviews"]
-				verbs: ["create"]
-			}]
-		}
+#ControllerClusterViewClusterRole: #ClusterRole & {
+	#config:    cfg.#Config
+	#component: "controller"
+	#role:      "cluster-view"
+	#aggregate: #config.rbac.aggregateClusterRoles == true
+	#aggregateTo: {
+		reader: true
 	}
+	rules: [{
+		apiGroups: ["cert-manager.io"]
+		resources: ["clusterissuers"]
+		verbs: ["get", "list", "watch"]
+	}]
+}
 
-	if #component == "webhook" {
-		if #role == "subjectaccessreviews" {
-			rules: [{
-				apiGroups: ["authorization.k8s.io"]
-				resources: ["subjectaccessreviews"]
-				verbs: ["create"]
-			}]
-		}
+#ControllerViewClusterRole: #ClusterRole & {
+	#config:    cfg.#Config
+	#component: "controller"
+	#role:      "view"
+	#aggregate: #config.rbac.aggregateClusterRoles == true
+	#aggregateTo: {
+		reader: true
+		view:   true
+		edit:   true
+		admin:  true
 	}
+	rules: [{
+		apiGroups: ["cert-manager.io"]
+		resources: ["certificates", "certificaterequests", "issuers"]
+		verbs: ["get", "list", "watch"]
+	}, {
+		apiGroups: ["acme.cert-manager.io"]
+		resources: ["challenges", "orders"]
+		verbs: ["get", "list", "watch"]
+	}]
+}
 
-	if #component == "cainjector" {
-		rules: [{
-			apiGroups: ["cert-manager.io"]
-			resources: ["certificates"]
-			verbs: ["get", "list", "watch"]
-		}, {
-			apiGroups: [""]
-			resources: ["secrets"]
-			verbs: ["get", "list", "watch"]
-		}, {
-			apiGroups: [""]
-			resources: ["events"]
-			verbs: ["get", "create", "update", "patch"]
-		}, {
-			apiGroups: ["admissionregistration.k8s.io"]
-			resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
-			verbs: ["get", "list", "watch", "update", "patch"]
-		}, {
-			apiGroups: ["apiregistration.k8s.io"]
-			resources: ["apiservices"]
-			verbs: ["get", "list", "watch", "update", "patch"]
-		}, {
-			apiGroups: ["apiextensions.k8s.io"]
-			resources: ["customresourcedefinitions"]
-			verbs: ["get", "list", "watch", "update", "patch"]
-		}]
+#ControllerEditClusterRole: #ClusterRole & {
+	#config:    cfg.#Config
+	#component: "controller"
+	#role:      "edit"
+	#aggregate: #config.rbac.aggregateClusterRoles == true
+	#aggregateTo: {
+		edit:  true
+		admin: true
 	}
+	rules: [{
+		apiGroups: ["cert-manager.io"]
+		resources: ["certificates", "certificaterequests", "issuers"]
+		verbs: ["create", "delete", "deletecollection", "patch", "update"]
+	}, {
+		apiGroups: ["cert-manager.io"]
+		resources: ["certificates/status"]
+		verbs: ["update"]
+	}, {
+		apiGroups: ["acme.cert-manager.io"]
+		resources: ["challenges", "orders"]
+		verbs: ["create", "delete", "deletecollection", "patch", "update"]
+	}]
+}
+
+#ControllerIssuersClusterRole: #ClusterRole & {
+	#config:    cfg.#Config
+	#component: "controller"
+	#role:      "issuers"
+	rules: [{
+		apiGroups: ["cert-manager.io"]
+		resources: ["issuers", "issuers/status"]
+		verbs: ["update", "patch"]
+	}, {
+		apiGroups: ["cert-manager.io"]
+		resources: ["issuers"]
+		verbs: ["get", "list", "watch"]
+	}, {
+		apiGroups: [""]
+		resources: ["secrets"]
+		verbs: ["get", "list", "watch", "create", "update", "delete"]
+	}, {
+		apiGroups: [""]
+		resources: ["events"]
+		verbs: ["create", "patch"]
+	}]
+}
+
+#ControllerClusterIssuersClusterRole: #ClusterRole & {
+	#config:    cfg.#Config
+	#component: "controller"
+	#role:      "clusterissuers"
+	rules: [{
+		apiGroups: ["cert-manager.io"]
+		resources: ["clusterissuers", "clusterissuers/status"]
+		verbs: ["update", "patch"]
+	}, {
+		apiGroups: ["cert-manager.io"]
+		resources: ["clusterissuers"]
+		verbs: ["get", "list", "watch"]
+	}, {
+		apiGroups: [""]
+		resources: ["secrets"]
+		verbs: ["get", "list", "watch", "create", "update", "delete"]
+	}, {
+		apiGroups: [""]
+		resources: ["events"]
+		verbs: ["create", "patch"]
+	}]
+}
+
+#ControllerCertificatesClusterRole: #ClusterRole & {
+	#config:    cfg.#Config
+	#component: "controller"
+	#role:      "certificates"
+	rules: [{
+		apiGroups: ["cert-manager.io"]
+		resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
+		verbs: ["update", "patch"]
+	}, {
+		apiGroups: ["cert-manager.io"]
+		resources: ["certificates", "certificaterequests", "clusterissuers", "issuers"]
+		verbs: ["get", "list", "watch"]
+	}, {
+		// We require these rules to support users with the OwnerReferencesPermissionEnforcement
+		// admission controller enabled:
+		// https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+		apiGroups: ["cert-manager.io"]
+		resources: ["certificates/finalizers", "certificaterequests/finalizers"]
+		verbs: ["update"]
+	}, {
+		apiGroups: ["acme.cert-manager.io"]
+		resources: ["orders"]
+		verbs: ["create", "delete", "get", "list", "watch"]
+	}, {
+		apiGroups: [""]
+		resources: ["secrets"]
+		verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+	}, {
+		apiGroups: [""]
+		resources: ["events"]
+		verbs: ["create", "patch"]
+	}]
+}
+
+#ControllerOrdersClusterRole: #ClusterRole & {
+	#config:    cfg.#Config
+	#component: "controller"
+	#role:      "orders"
+	rules: [{
+		apiGroups: ["acme.cert-manager.io"]
+		resources: ["orders", "orders/status"]
+		verbs: ["update", "patch"]
+	}, {
+		apiGroups: ["acme.cert-manager.io"]
+		resources: ["orders", "challenges"]
+		verbs: ["get", "list", "watch"]
+	}, {
+		apiGroups: ["cert-manager.io"]
+		resources: ["clusterissuers", "issuers"]
+		verbs: ["get", "list", "watch"]
+	}, {
+		apiGroups: ["acme.cert-manager.io"]
+		resources: ["challenges"]
+		verbs: ["create", "delete"]
+	}, {
+		// We require these rules to support users with the OwnerReferencesPermissionEnforcement
+		// admission controller enabled:
+		// https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+		apiGroups: ["acme.cert-manager.io"]
+		resources: ["orders/finalizers"]
+		verbs: ["update"]
+	}, {
+		apiGroups: [""]
+		resources: ["secrets"]
+		verbs: ["get", "list", "watch"]
+	}, {
+		apiGroups: [""]
+		resources: ["events"]
+		verbs: ["create", "patch"]
+	}]
+}
+
+#ControllerChallengesClusterRole: #ClusterRole & {
+	#config:    cfg.#Config
+	#component: "controller"
+	#role:      "challenges"
+	rules: [{
+		// Use to update challenge resource status
+		apiGroups: ["acme.cert-manager.io"]
+		resources: ["challenges", "challenges/status"]
+		verbs: ["update", "patch"]
+	}, {
+		// Used to watch challenge resources
+		apiGroups: ["acme.cert-manager.io"]
+		resources: ["challenges"]
+		verbs: ["get", "list", "watch"]
+	}, {
+		// Used to watch challenges, issuer and clusterissuer resources
+		apiGroups: ["cert-manager.io"]
+		resources: ["issuers", "clusterissuers"]
+		verbs: ["get", "list", "watch"]
+	}, {
+		// Need to be able to retrieve ACME account private key to complete challenges
+		apiGroups: [""]
+		resources: ["secrets"]
+		verbs: ["get", "list", "watch"]
+	}, {
+		// Used to create events
+		apiGroups: [""]
+		resources: ["events"]
+		verbs: ["create", "patch"]
+	}, {
+		// HTTP01 rules
+		apiGroups: [""]
+		resources: ["pods", "services"]
+		verbs: ["get", "list", "watch", "create", "delete"]
+	}, {
+		apiGroups: ["networking.k8s.io"]
+		resources: ["ingresses"]
+		verbs: ["get", "list", "watch", "create", "delete", "update"]
+	}, {
+		apiGroups: ["gateway.networking.k8s.io"]
+		resources: ["httproutes"]
+		verbs: ["get", "list", "watch", "create", "delete", "update"]
+	}, {
+		// We require the ability to specify a custom hostname when we are creating
+		// new ingress resources.
+		// See: https://github.com/openshift/origin/blob/21f191775636f9acadb44fa42beeb4f75b255532/pkg/route/apiserver/admission/ingress_admission.go#L84-L148
+		apiGroups: ["route.openshift.io"]
+		resources: ["routes/custom-host"]
+		verbs: ["create"]
+	}, {
+		// We require these rules to support users with the OwnerReferencesPermissionEnforcement
+		// admission controller enabled:
+		// https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+		apiGroups: ["acme.cert-manager.io"]
+		resources: ["challenges/finalizers"]
+		verbs: ["update"]
+	}, {
+		// DNS01 rules (duplicated above)
+		apiGroups: [""]
+		resources: ["secrets"]
+		verbs: ["get", "list", "watch"]
+	}]
+}
+
+#ControllerIngressShimClusterRole: #ClusterRole & {
+	#config:    cfg.#Config
+	#component: "controller"
+	#role:      "ingress-shim"
+	rules: [{
+		apiGroups: ["cert-manager.io"]
+		resources: ["certificates", "certificaterequests"]
+		verbs: ["create", "update", "delete"]
+	}, {
+		apiGroups: ["cert-manager.io"]
+		resources: ["certificates", "certificaterequests", "issuers", "clusterissuers"]
+		verbs: ["get", "list", "watch"]
+	}, {
+		apiGroups: ["networking.k8s.io"]
+		resources: ["ingresses"]
+		verbs: ["get", "list", "watch"]
+	}, {
+		// We require these rules to support users with the OwnerReferencesPermissionEnforcement
+		// admission controller enabled:
+		// https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
+		apiGroups: ["networking.k8s.io"]
+		resources: ["ingresses/finalizers"]
+		verbs: ["update"]
+	}, {
+		apiGroups: ["gateway.networking.k8s.io"]
+		resources: ["gateways", "httproutes"]
+		verbs: ["get", "list", "watch"]
+	}, {
+		apiGroups: ["gateway.networking.k8s.io"]
+		resources: ["gateways/finalizers", "httproutes/finalizers"]
+		verbs: ["update"]
+	}, {
+		apiGroups: [""]
+		resources: ["events"]
+		verbs: ["create", "patch"]
+	}]
+}
+
+#ControllerApproveClusterRole: #ClusterRole & {
+	#config:    cfg.#Config
+	#component: "controller"
+	#role:      "approve:cert-manager-io"
+	rules: [{
+		apiGroups: ["cert-manager.io"]
+		resources: ["signers"]
+		verbs: ["approve"]
+		resourceNames: ["issuers.cert-manager.io/*", "clusterissuers.cert-manager.io/*"]
+	}]
+}
+
+#ControllerCertificateSigningRequestsClusterRole: #ClusterRole & {
+	#config:    cfg.#Config
+	#component: "controller"
+	#role:      "certificatesigningrequests"
+	rules: [{
+		apiGroups: ["certificates.k8s.io"]
+		resources: ["certificatesigningrequests"]
+		verbs: ["get", "list", "watch", "update"]
+	}, {
+		apiGroups: ["certificates.k8s.io"]
+		resources: ["certificatesigningrequests/status"]
+		verbs: ["update", "patch"]
+	}, {
+		apiGroups: ["certificates.k8s.io"]
+		resources: ["signers"]
+		resourceNames: ["issuers.cert-manager.io/*", "clusterissuers.cert-manager.io/*"]
+		verbs: ["sign"]
+	}, {
+		apiGroups: ["authorization.k8s.io"]
+		resources: ["subjectaccessreviews"]
+		verbs: ["create"]
+	}]
+}
+
+#ClusterWebhookClusterRole: #ClusterRole & {
+	#config:    cfg.#Config
+	#component: "webhook"
+	#role:      "subjectaccessreviews"
+	rules: [{
+		apiGroups: ["authorization.k8s.io"]
+		resources: ["subjectaccessreviews"]
+		verbs: ["create"]
+	}]
+}
+
+#CaInjectorClusterRole: #ClusterRole & {
+	#config:    cfg.#Config
+	#component: "caInjector"
+	rules: [{
+		apiGroups: ["cert-manager.io"]
+		resources: ["certificates"]
+		verbs: ["get", "list", "watch"]
+	}, {
+		apiGroups: [""]
+		resources: ["secrets"]
+		verbs: ["get", "list", "watch"]
+	}, {
+		apiGroups: [""]
+		resources: ["events"]
+		verbs: ["get", "create", "update", "patch"]
+	}, {
+		apiGroups: ["admissionregistration.k8s.io"]
+		resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
+		verbs: ["get", "list", "watch", "update", "patch"]
+	}, {
+		apiGroups: ["apiregistration.k8s.io"]
+		resources: ["apiservices"]
+		verbs: ["get", "list", "watch", "update", "patch"]
+	}, {
+		apiGroups: ["apiextensions.k8s.io"]
+		resources: ["customresourcedefinitions"]
+		verbs: ["get", "list", "watch", "update", "patch"]
+	}]
 }

--- a/templates/clusterRoleBinding.cue
+++ b/templates/clusterRoleBinding.cue
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"strings"
 	rbacv1 "k8s.io/api/rbac/v1"
 	timoniv1 "timoni.sh/core/v1alpha1"
 
@@ -14,7 +15,7 @@ import (
 
 	#meta: timoniv1.#MetaComponent & {
 		#Meta:      #config.metadata
-		#Component: #component
+		#Component: strings.ToLower(#component)
 	}
 
 	apiVersion: "rbac.authorization.k8s.io/v1"

--- a/templates/deployment.cue
+++ b/templates/deployment.cue
@@ -1,73 +1,165 @@
 package templates
 
 import (
+	"strings"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	timoniv1 "timoni.sh/core/v1alpha1"
 
 	cfg "timoni.sh/cert-manager/templates/config"
 )
 
 #Deployment: appsv1.#Deployment & {
-	#config:      cfg.#Config
-	#component:   string
-	#strategy?:   appsv1.#DeploymentStrategy
-	#monitoring?: cfg.#Monitoring
+	#config:    cfg.#Config
+	#meta:      timoniv1.#MetaComponent
+	#component: string
 
-	#meta: timoniv1.#MetaComponent & {
-		#Meta:      #config.metadata
-		#Component: #component
+	#monitoring?: #config[#component].monitoring
+
+	if #config[#component].deploymentLabels != _|_ {
+		metadata: labels: #config[#component].deploymentLabels
+	}
+
+	if #config[#component].deploymentAnnotations != _|_ {
+		metadata: annotations: #config[#component].deploymentAnnotations
 	}
 
 	apiVersion: "apps/v1"
 	kind:       "Deployment"
 	metadata:   #meta
 
-	if #component == "controller" {
-		if #config.controller.deploymentLabels != _|_ {
-			metadata: labels: #config.controller.deploymentLabels
+	spec: appsv1.#DeploymentSpec & {
+
+		selector: matchLabels: #meta.#LabelSelector
+
+		if #config.highAvailability.enabled {
+			replicas: #config.highAvailability[#component+"Replicas"]
 		}
 
-		if #config.controller.deploymentAnnotations != _|_ {
-			metadata: annotations: #config.controller.deploymentAnnotations
+		if !#config.highAvailability.enabled {
+			replicas: #config[#component].replicas
+		}
+		if #config[#component].strategy != _|_ {
+			strategy: appsv1.#DeploymentStrategy & #config[#component].strategy
 		}
 
-		spec: #ControllerDeploymentSpec & {
-			#main_config:           #config
-			#deployment_meta:       #meta
-			#deployment_strategy:   #strategy
-			#deployment_prometheus: #monitoring
+		template: corev1.#PodTemplateSpec & {
+			metadata: labels: #meta.labels
+
+			if #config[#component].podLabels != _|_ {
+				metadata: labels: #config[#component].podLabels
+			}
+
+			if #config[#component].podAnnotations != _|_ {
+				metadata: annotations: #config[#component].podAnnotations
+			}
+
+			spec: corev1.#PodSpec & {
+
+				containers: [...corev1.#Container] & [
+					{
+						name:            #meta.name
+						image:           #config[#component].image.reference
+						imagePullPolicy: #config[#component].image.pullPolicy
+
+						if #config[#component].containerSecurityContext != _|_ {
+							securityContext: #config[#component].containerSecurityContext
+						}
+
+						if #config[#component].resources != _|_ {
+							resources: #config[#component].resources
+						}
+						env: [
+							{
+								name: "POD_NAMESPACE"
+								valueFrom: fieldRef: fieldPath: "metadata.namespace"
+							},
+
+							if #config[#component].extraEnvs != _|_ {
+								for e in #config[#component].extraEnvs {e}
+							},
+						]
+					}]
+				serviceAccountName: #meta.name
+				securityContext:    #config[#component].securityContext
+
+				if #config[#component].automountServiceAccountToken != _|_ {
+					automountServiceAccountToken: #config[#component].automountServiceAccountToken
+				}
+
+				if #config[#component].enableServiceLinks != _|_ {
+					enableServiceLinks: #config[#component].enableServiceLinks
+				}
+
+				if #config.priorityClass != _|_ {
+					priorityClassName: #config.priorityClass
+				}
+
+				if #config[#component].nodeSelector != _|_ {
+					nodeSelector: #config[#component].nodeSelector
+				}
+
+				if #config[#component].affinity != _|_ {
+					affinity: #config[#component].affinity
+				}
+
+				if #config[#component].tolerations != _|_ {
+					tolerations: #config[#component].tolerations
+				}
+
+				if #config[#component].topologySpreadConstraints != _|_ {
+					topologySpreadConstraints: #config[#component].topologySpreadConstraints
+				}
+
+				if #config[#component].podDNSPolicy != _|_ {
+					dnsPolicy: #config[#component].podDNSPolicy
+				}
+
+				if #config[#component].podDNSConfig != _|_ {
+					dnsConfig: #config[#component].podDNSConfig
+				}
+			}
 		}
 	}
 
-	if #component == "webhook" {
-		if #config.webhook.deploymentLabels != _|_ {
-			metadata: labels: #config.webhook.deploymentLabels
-		}
+}
 
-		if #config.webhook.deploymentAnnotations != _|_ {
-			metadata: annotations: #config.webhook.deploymentAnnotations
-		}
+#ControllerDeployment: #Deployment & {
+	#config:    cfg.#Config
+	#component: "controller"
 
-		spec: #WebhookDeploymentSpec & {
-			#main_config:         #config
-			#deployment_meta:     #meta
-			#deployment_strategy: #strategy
-		}
+	#meta: timoniv1.#MetaComponent & {
+		#Meta:      #config.metadata
+		#Component: strings.ToLower(#component)
 	}
+	spec: #ControllerDeploymentSpec & {
+		#config:          #config
+		#deployment_meta: #meta
+	}
+}
 
-	if #component == "cainjector" {
-		if #config.caInjector.deploymentLabels != _|_ {
-			metadata: labels: #config.caInjector.deploymentLabels
-		}
+#WebhookDeployment: #Deployment & {
+	#config:    cfg.#Config
+	#component: "webhook"
+	#meta: timoniv1.#MetaComponent & {
+		#Meta:      #config.metadata
+		#Component: strings.ToLower(#component)
+	}
+	spec: #WebhookDeploymentSpec & {
+		#config:          #config
+		#deployment_meta: #meta
+	}
+}
 
-		if #config.caInjector.deploymentAnnotations != _|_ {
-			metadata: annotations: #config.caInjector.deploymentAnnotations
-		}
-
-		spec: #CAInjectorDeploymentSpec & {
-			#main_config:         #config
-			#deployment_meta:     #meta
-			#deployment_strategy: #strategy
-		}
+#CaInjectorrDeployment: #Deployment & {
+	#config:    cfg.#Config
+	#component: "caInjector"
+	#meta: timoniv1.#MetaComponent & {
+		#Meta:      #config.metadata
+		#Component: strings.ToLower(#component)
+	}
+	spec: #CAInjectorDeploymentSpec & {
+		#config:          #config
+		#deployment_meta: #meta
 	}
 }

--- a/templates/deploymentSpecCAInjector.cue
+++ b/templates/deploymentSpecCAInjector.cue
@@ -9,60 +9,17 @@ import (
 )
 
 #CAInjectorDeploymentSpec: appsv1.#DeploymentSpec & {
-	#main_config:          cfg.#Config
-	#deployment_meta:      timoniv1.#MetaComponent
-	#deployment_strategy?: appsv1.#DeploymentStrategy
-
-	if #main_config.highAvailability.enabled {
-		replicas: #main_config.highAvailability.caInjectorReplicas
-	}
-
-	if !#main_config.highAvailability.enabled {
-		replicas: #main_config.caInjector.replicas
-	}
+	#main_config:     cfg.#Config
+	#deployment_meta: timoniv1.#MetaComponent
 
 	selector: matchLabels: #deployment_meta.#LabelSelector
 
-	if #deployment_strategy != _|_ {
-		strategy: #deployment_strategy
-	}
-
 	template: corev1.#PodTemplateSpec & {
-		metadata: labels: #deployment_meta.labels
-
-		if #main_config.caInjector.podLabels != _|_ {
-			metadata: labels: #main_config.caInjector.podLabels
-		}
-
-		if #main_config.caInjector.podAnnotations != _|_ {
-			metadata: annotations: #main_config.caInjector.podAnnotations
-		}
 
 		spec: corev1.#PodSpec & {
-			serviceAccountName: #deployment_meta.name
-
-			if #main_config.caInjector.automountServiceAccountToken != _|_ {
-				automountServiceAccountToken: #main_config.caInjector.automountServiceAccountToken
-			}
-
-			if #main_config.caInjector.enableServiceLinks != _|_ {
-				enableServiceLinks: #main_config.caInjector.enableServiceLinks
-			}
-
-			if #main_config.priorityClass != _|_ {
-				priorityClassName: #main_config.priorityClass
-			}
-
-			if #main_config.caInjector.securityContext != _|_ {
-				securityContext: #main_config.caInjector.securityContext
-			}
 
 			containers: [...corev1.#Container] & [
 				{
-					name:            #deployment_meta.name
-					image:           #main_config.caInjector.image.reference
-					imagePullPolicy: #main_config.caInjector.image.pullPolicy
-
 					args: [
 						"--v=\(#main_config.logLevel)",
 						"--leader-election-namespace=\(#main_config.leaderElection.namespace)",
@@ -84,46 +41,11 @@ import (
 						},
 					]
 
-					env: [
-						{
-							name: "POD_NAMESPACE"
-							valueFrom: fieldRef: fieldPath: "metadata.namespace"
-						},
-
-						if #main_config.caInjector.extraEnvs != _|_ {
-							for e in #main_config.caInjector.extraEnvs {e}
-						},
-					]
-
-					if #main_config.caInjector.containerSecurityContext != _|_ {
-						securityContext: #main_config.caInjector.containerSecurityContext
-					}
-
-					if #main_config.caInjector.resources != _|_ {
-						resources: #main_config.caInjector.resources
-					}
-
 					if #main_config.caInjector.volumeMounts != _|_ {
 						volumeMounts: #main_config.caInjector.volumeMounts
 					}
 				},
 			]
-
-			if #main_config.caInjector.nodeSelector != _|_ {
-				nodeSelector: #main_config.caInjector.nodeSelector
-			}
-
-			if #main_config.caInjector.affinity != _|_ {
-				affinity: #main_config.caInjector.affinity
-			}
-
-			if #main_config.caInjector.tolerations != _|_ {
-				tolerations: #main_config.caInjector.tolerations
-			}
-
-			if #main_config.caInjector.topologySpreadConstraints != _|_ {
-				topologySpreadConstraints: #main_config.caInjector.topologySpreadConstraints
-			}
 
 			if #main_config.caInjector.volumes != _|_ {
 				volumes: #main_config.caInjector.volumes

--- a/templates/deploymentSpecController.cue
+++ b/templates/deploymentSpecController.cue
@@ -14,14 +14,6 @@ import (
 	#deployment_strategy?:   appsv1.#DeploymentStrategy
 	#deployment_monitoring?: cfg.#Monitoring
 
-	if #main_config.highAvailability.enabled {
-		replicas: #main_config.highAvailability.controllerReplicas
-	}
-
-	if !#main_config.highAvailability.enabled {
-		replicas: #main_config.controller.replicas
-	}
-
 	selector: matchLabels: #deployment_meta.#LabelSelector
 
 	if #deployment_strategy != _|_ {
@@ -29,15 +21,6 @@ import (
 	}
 
 	template: corev1.#PodTemplateSpec & {
-		metadata: labels: #deployment_meta.labels
-
-		if #main_config.controller.podLabels != _|_ {
-			metadata: labels: #main_config.controller.podLabels
-		}
-
-		if #main_config.controller.podAnnotations != _|_ {
-			metadata: annotations: #main_config.controller.podAnnotations
-		}
 
 		if #deployment_monitoring != _|_ && #deployment_monitoring.serviceMonitor == _|_ {
 			metadata: annotations: "prometheus.io/path":   "/metrics"
@@ -46,21 +29,6 @@ import (
 		}
 
 		spec: corev1.#PodSpec & {
-			serviceAccountName: #deployment_meta.name
-
-			if #main_config.controller.automountServiceAccountToken != _|_ {
-				automountServiceAccountToken: #main_config.controller.automountServiceAccountToken
-			}
-
-			if #main_config.controller.enableServiceLinks != _|_ {
-				enableServiceLinks: #main_config.controller.enableServiceLinks
-			}
-
-			if #main_config.priorityClass != _|_ {
-				priorityClassName: #main_config.priorityClass
-			}
-
-			securityContext: #main_config.controller.securityContext
 
 			if #main_config.controller.volumes != _|_ || #main_config.controller.config != _|_ {
 				volumes: [
@@ -80,14 +48,6 @@ import (
 
 			containers: [...corev1.#Container] & [
 				{
-					name: #deployment_meta.name
-
-					image:           #main_config.controller.image.reference
-					imagePullPolicy: #main_config.controller.image.pullPolicy
-
-					if #main_config.controller.containerSecurityContext != _|_ {
-						securityContext: #main_config.controller.containerSecurityContext
-					}
 
 					if #main_config.controller.volumeMounts != _|_ || #main_config.controller.config != _|_ {
 						volumeMounts: [
@@ -177,17 +137,6 @@ import (
 						},
 					]
 
-					env: [
-						{
-							name: "POD_NAMESPACE"
-							valueFrom: fieldRef: fieldPath: "metadata.namespace"
-						},
-
-						if #main_config.controller.extraEnvs != _|_ {
-							for e in #main_config.controller.extraEnvs {e}
-						},
-					]
-
 					if #main_config.controller.proxy != _|_ {
 						env: [
 							if #main_config.controller.proxy.httpProxy != _|_ {
@@ -211,10 +160,6 @@ import (
 						]
 					}
 
-					if #main_config.controller.resources != _|_ {
-						resources: #main_config.controller.resources
-					}
-
 					if #main_config.controller.livenessProbe != _|_ {
 						livenessProbe: #main_config.controller.livenessProbe & {
 							httpGet: {
@@ -231,30 +176,6 @@ import (
 					}
 				},
 			]
-
-			if #main_config.controller.nodeSelector != _|_ {
-				nodeSelector: #main_config.controller.nodeSelector
-			}
-
-			if #main_config.controller.affinity != _|_ {
-				affinity: #main_config.controller.affinity
-			}
-
-			if #main_config.controller.tolerations != _|_ {
-				tolerations: #main_config.controller.tolerations
-			}
-
-			if #main_config.controller.topologySpreadConstraints != _|_ {
-				topologySpreadConstraints: #main_config.controller.topologySpreadConstraints
-			}
-
-			if #main_config.controller.podDNSPolicy != _|_ {
-				dnsPolicy: #main_config.controller.podDNSPolicy
-			}
-
-			if #main_config.controller.podDNSConfig != _|_ {
-				dnsConfig: #main_config.controller.podDNSConfig
-			}
 		}
 	}
 }

--- a/templates/deploymentSpecWebhook.cue
+++ b/templates/deploymentSpecWebhook.cue
@@ -13,14 +13,6 @@ import (
 	#deployment_meta:      timoniv1.#MetaComponent
 	#deployment_strategy?: appsv1.#DeploymentStrategy
 
-	if #main_config.highAvailability.enabled {
-		replicas: #main_config.highAvailability.webhookReplicas
-	}
-
-	if !#main_config.highAvailability.enabled {
-		replicas: #main_config.webhook.replicas
-	}
-
 	selector: matchLabels: #deployment_meta.#LabelSelector
 
 	if #deployment_strategy != _|_ {
@@ -28,28 +20,8 @@ import (
 	}
 
 	template: corev1.#PodTemplateSpec & {
-		metadata: labels: #deployment_meta.labels
-
-		if #main_config.webhook.podLabels != _|_ {
-			metadata: labels: #main_config.webhook.podLabels
-		}
-
-		if #main_config.webhook.podAnnotations != _|_ {
-			metadata: annotations: #main_config.webhook.podAnnotations
-		}
 
 		spec: corev1.#PodSpec & {
-			enableServiceLinks: #main_config.webhook.enableServiceLinks
-			securityContext:    #main_config.webhook.securityContext
-			serviceAccountName: #deployment_meta.name
-
-			if #main_config.webhook.automountServiceAccountToken != _|_ {
-				automountServiceAccountToken: #main_config.webhook.automountServiceAccountToken
-			}
-
-			if #main_config.priorityClass != _|_ {
-				priorityClassName: #main_config.priorityClass
-			}
 
 			if #main_config.webhook.hostNetwork != false {
 				hostNetwork: true
@@ -58,11 +30,6 @@ import (
 
 			containers: [...corev1.#Container] & [
 				{
-					name: #deployment_meta.name
-
-					image:           #main_config.webhook.image.reference
-					imagePullPolicy: #main_config.webhook.image.pullPolicy
-
 					args: [
 						"--v=\(#main_config.logLevel)",
 
@@ -159,25 +126,6 @@ import (
 						}
 					}
 
-					if #main_config.webhook.containerSecurityContext != _|_ {
-						securityContext: #main_config.webhook.containerSecurityContext
-					}
-
-					env: [
-						{
-							name: "POD_NAMESPACE"
-							valueFrom: fieldRef: fieldPath: "metadata.namespace"
-						},
-
-						if #main_config.webhook.extraEnvs != _|_ {
-							for e in #main_config.webhook.extraEnvs {e}
-						},
-					]
-
-					if #main_config.webhook.resources != _|_ {
-						resources: #main_config.webhook.resources
-					}
-
 					if #main_config.webhook.volumeMounts != _|_ || #main_config.webhook.config != _|_ {
 						volumeMounts: [
 							if #main_config.webhook.config != _|_ {
@@ -193,22 +141,6 @@ import (
 					}
 				},
 			]
-
-			if #main_config.webhook.nodeSelector != _|_ {
-				nodeSelector: #main_config.webhook.nodeSelector
-			}
-
-			if #main_config.webhook.affinity != _|_ {
-				affinity: #main_config.webhook.affinity
-			}
-
-			if #main_config.webhook.tolerations != _|_ {
-				tolerations: #main_config.webhook.tolerations
-			}
-
-			if #main_config.webhook.topologySpreadConstraints != _|_ {
-				topologySpreadConstraints: #main_config.webhook.topologySpreadConstraints
-			}
 
 			if #main_config.webhook.volumes != _|_ || #main_config.webhook.config != _|_ {
 				volumes: [

--- a/templates/instance.cue
+++ b/templates/instance.cue
@@ -20,64 +20,42 @@ import (
 
 	objects: {
 		namespace: #Namespace & {#config: config}
-		controllerDeployment: #Deployment & {
-			#config:     config
-			#component:  "controller"
-			#strategy:   #config.controller.strategy
-			#monitoring: #config.controller.monitoring
-		}
-		webhookDeployment: #Deployment & {
-			#config:    config
-			#component: "webhook"
-			#strategy:  #config.webhook.strategy
-		}
+		controllerDeployment: #ControllerDeployment & {#config: config}
+		webhookDeployment: #WebhookDeployment & {#config: config}
 		webhookMutatingWebhook: #MutatingWebhook & {#config: config}
 		webhookValidatingWebhook: #ValidatingWebhook & {#config: config}
-		webhookService: #Service & {
-			#config:    config
-			#component: "webhook"
-		}
+		webhookService: #ServiceWebhook & {#config: config}
 	}
 
 	if config.caInjector != _|_ {
 		if config.caInjector.podDisruptionBudget.enabled {
 			objects: caInjectorPodDisruptionBudget: #PodDisruptionBudget & {
 				#config:    config
-				#component: "cainjector"
+				#component: "caInjector"
 			}
 		}
 
 		if config.rbac.enabled {
 			objects: {
-				caInjectorClusterRole: #ClusterRole & {
+				caInjectorClusterRole: #CaInjectorClusterRole & {
 					#config:    config
-					#component: "cainjector"
+					#component: "caInjector"
 				}
 				caInjectorClusterRoleBinding: #ClusterRoleBinding & {
 					#config:    config
-					#component: "cainjector"
+					#component: "caInjector"
 				}
-				caInjectorRole: #Role & {
-					#config:    config
-					#component: "cainjector"
-				}
-				caInjectorRoleBinding: #RoleBinding & {
-					#config:    config
-					#component: "cainjector"
-				}
+				caInjectorRole: #CaInjectorRole & {#config: config}
+				caInjectorRoleBinding: #CaInjectorRoleBinding & {#config: config}
 			}
 		}
 
 		objects: caInjectorServiceAccount: #ServiceAccount & {
 			#config:    config
-			#component: "cainjector"
+			#component: "caInjector"
 		}
 
-		objects: caInjectorDeployment: #Deployment & {
-			#config:    config
-			#component: "cainjector"
-			#strategy:  #config.caInjector.strategy
-		}
+		objects: caInjectorDeployment: #CaInjectorrDeployment & {#config: config}
 	}
 
 	if config.controller.config != _|_ {
@@ -93,10 +71,11 @@ import (
 				#config:    config
 				#component: "webhook"
 			}
-			webhookNetworkPolicyIngress: #NetworkPolicyAllowIngress & {
-				#config:    config
-				#component: "webhook"
-			}
+			webhookNetworkPolicyIngress:
+				#NetworkPolicyAllowIngress & {
+					#config:    config
+					#component: "webhook"
+				}
 		}
 	}
 
@@ -109,90 +88,24 @@ import (
 
 	if config.rbac.enabled {
 		objects: {
-			controllerRole: #Role & {
-				#config:    config
-				#component: "controller"
-			}
-			controllerRoleBinding: #RoleBinding & {
-				#config:    config
-				#component: "controller"
-			}
+			controllerRole: #ControllerRole & {#config: config}
+			controllerRoleBinding: #ControllerRoleBinding & {#config: config}
 
 			if config.rbac.aggregateClusterRoles {
-				controllerClusterViewClusterRole: #ClusterRole & {
-					#config:    config
-					#component: "controller"
-					#role:      "cluster-view"
-					#aggregate: config.rbac.aggregateClusterRoles == true
-					#aggregateTo: {
-						reader: true
-					}
+				controllerClusterViewClusterRole: #ControllerClusterViewClusterRole & {
+					#config: config
 				}
 			}
-
-			controllerViewClusterRole: #ClusterRole & {
-				#config:    config
-				#component: "controller"
-				#role:      "view"
-				#aggregate: config.rbac.aggregateClusterRoles == true
-				#aggregateTo: {
-					reader: true
-					view:   true
-					edit:   true
-					admin:  true
-				}
-			}
-			controllerEditClusterRole: #ClusterRole & {
-				#config:    config
-				#component: "controller"
-				#role:      "edit"
-				#aggregate: config.rbac.aggregateClusterRoles == true
-				#aggregateTo: {
-					edit:  true
-					admin: true
-				}
-			}
-
-			controllerIssuersClusterRole: #ClusterRole & {
-				#config:    config
-				#component: "controller"
-				#role:      "issuers"
-			}
-			controllerClusterIssuersClusterRole: #ClusterRole & {
-				#config:    config
-				#component: "controller"
-				#role:      "clusterissuers"
-			}
-			controllerCertificatesClusterRole: #ClusterRole & {
-				#config:    config
-				#component: "controller"
-				#role:      "certificates"
-			}
-			controllerOrdersClusterRole: #ClusterRole & {
-				#config:    config
-				#component: "controller"
-				#role:      "orders"
-			}
-			controllerChallengesClusterRole: #ClusterRole & {
-				#config:    config
-				#component: "controller"
-				#role:      "challenges"
-			}
-			controllerIngressShimClusterRole: #ClusterRole & {
-				#config:    config
-				#component: "controller"
-				#role:      "ingress-shim"
-			}
-			controllerApproveClusterRole: #ClusterRole & {
-				#config:    config
-				#component: "controller"
-				#role:      "approve:cert-manager-io"
-			}
-			controllerCertificateSigningRequestsClusterRole: #ClusterRole & {
-				#config:    config
-				#component: "controller"
-				#role:      "certificatesigningrequests"
-			}
+			controllerViewClusterRole: #ControllerViewClusterRole & {#config: config}
+			controllerEditClusterRole: #ControllerEditClusterRole & {#config: config}
+			controllerIssuersClusterRole: #ControllerIssuersClusterRole & {#config: config}
+			controllerClusterIssuersClusterRole: #ControllerClusterIssuersClusterRole & {#config: config}
+			controllerCertificatesClusterRole: #ControllerCertificatesClusterRole & {#config: config}
+			controllerOrdersClusterRole: #ControllerOrdersClusterRole & {#config: config}
+			controllerChallengesClusterRole: #ControllerChallengesClusterRole & {#config: config}
+			controllerIngressShimClusterRole: #ControllerIngressShimClusterRole & {#config: config}
+			controllerApproveClusterRole: #ControllerApproveClusterRole & {#config: config}
+			controllerCertificateSigningRequestsClusterRole: #ControllerCertificateSigningRequestsClusterRole & {#config: config}
 
 			controllerIssuersClusterRoleBinding: #ClusterRoleBinding & {
 				#config:    config
@@ -235,19 +148,9 @@ import (
 				#role:      "certificatesigningrequests"
 			}
 
-			webhookRole: #Role & {
-				#config:    config
-				#component: "webhook"
-			}
-			webhookRoleBinding: #RoleBinding & {
-				#config:    config
-				#component: "webhook"
-			}
-			webhookClusterRole: #ClusterRole & {
-				#config:    config
-				#component: "webhook"
-				#role:      "subjectaccessreviews"
-			}
+			webhookRole: #WebhookRole & {#config: config}
+			webhookRoleBinding: #WebhookRoleBinding & {#config: config}
+			webhookClusterRole: #ClusterWebhookClusterRole & {#config: config}
 			webhookClusterRoleBinding: #ClusterRoleBinding & {
 				#config:    config
 				#component: "webhook"
@@ -258,10 +161,7 @@ import (
 
 	if config.controller.monitoring.enabled && config.controller.monitoring.serviceMonitor.enabled {
 		objects: {
-			service: #Service & {
-				#config:    config
-				#component: "controller"
-			}
+			service: #ServiceController & {#config: config}
 			serviceMonitor: #ServiceMonitor & {
 				#config:    config
 				#component: "controller"
@@ -298,20 +198,14 @@ import (
 
 		if config.rbac.enabled {
 			tests: {
-				startupAPICheckRole: #Role & {
-					#config:    config
-					#component: "startupapicheck"
-				}
-				startupAPICheckRoleBinding: #RoleBinding & {
-					#config:    config
-					#component: "startupapicheck"
-				}
+				startupAPICheckRole: #StartupApiCheckRole & {#config: config}
+				startupAPICheckRoleBinding: #StartupApiCheckRoleBinding & {#config: config}
 			}
 		}
 
 		tests: startupAPICheckServiceAccount: #ServiceAccount & {
 			#config:    config
-			#component: "startupapicheck"
+			#component: "startupAPICheck"
 		}
 	}
 }

--- a/templates/podDisruptionBudget.cue
+++ b/templates/podDisruptionBudget.cue
@@ -1,9 +1,9 @@
 package templates
 
 import (
+	"strings"
 	policyv1 "k8s.io/api/policy/v1"
 	timoniv1 "timoni.sh/core/v1alpha1"
-
 	cfg "timoni.sh/cert-manager/templates/config"
 )
 
@@ -13,7 +13,7 @@ import (
 
 	#meta: timoniv1.#MetaComponent & {
 		#Meta:      #config.metadata
-		#Component: #component
+		#Component: strings.ToLower(#component)
 	}
 
 	apiVersion: "policy/v1"
@@ -22,37 +22,12 @@ import (
 
 	spec: {
 		selector: matchLabels: #meta.#LabelSelector
-
-		if #component == "controller" {
-			if #config.controller.podDisruptionBudget != _|_ {
-				if #config.controller.podDisruptionBudget.minAvailable != _|_ {
-					minAvailable: #config.controller.podDisruptionBudget.minAvailable
-				}
-				if #config.controller.podDisruptionBudget.maxUnavailable != _|_ {
-					maxUnavailable: #config.controller.podDisruptionBudget.maxUnavailable
-				}
+		if #config[#component].podDisruptionBudget != _|_ {
+			if #config[#component].podDisruptionBudget.minAvailable != _|_ {
+				minAvailable: #config[#component].podDisruptionBudget.minAvailable
 			}
-		}
-
-		if #component == "webhook" {
-			if #config.webhook.podDisruptionBudget != _|_ {
-				if #config.webhook.podDisruptionBudget.minAvailable != _|_ {
-					minAvailable: #config.webhook.podDisruptionBudget.minAvailable
-				}
-				if #config.webhook.podDisruptionBudget.maxUnavailable != _|_ {
-					maxUnavailable: #config.webhook.podDisruptionBudget.maxUnavailable
-				}
-			}
-		}
-
-		if #component == "cainjector" {
-			if #config.caInjector.podDisruptionBudget != _|_ {
-				if #config.caInjector.podDisruptionBudget.minAvailable != _|_ {
-					minAvailable: #config.caInjector.podDisruptionBudget.minAvailable
-				}
-				if #config.caInjector.podDisruptionBudget.maxUnavailable != _|_ {
-					maxUnavailable: #config.caInjector.podDisruptionBudget.maxUnavailable
-				}
+			if #config[#component].podDisruptionBudget.maxUnavailable != _|_ {
+				maxUnavailable: #config[#component].podDisruptionBudget.maxUnavailable
 			}
 		}
 	}

--- a/templates/role.cue
+++ b/templates/role.cue
@@ -1,6 +1,7 @@
 package templates
 
 import (
+	"strings"
 	rbacv1 "k8s.io/api/rbac/v1"
 	timoniv1 "timoni.sh/core/v1alpha1"
 
@@ -8,90 +9,86 @@ import (
 )
 
 #Role: rbacv1.#Role & {
-	#config:    cfg.#Config
-	#component: string
+	#config:     cfg.#Config
+	#component:  string
+	#roleSuffix: string
+	#namespace?: string
 
 	#meta: timoniv1.#MetaComponent & {
 		#Meta:      #config.metadata
-		#Component: #component
+		#Component: strings.ToLower(#component)
 	}
-
 	apiVersion: "rbac.authorization.k8s.io/v1"
 	kind:       "Role"
 	metadata: {
-		if #component == "controller" || #component == "cainjector" {
-			name: "\(#meta.name):leaderelection"
-		}
-
-		if #component == "startupapicheck" {
-			name: "\(#meta.name):create-cert"
-		}
-
-		if #component == "webhook" {
-			name: "\(#meta.name):dynamic-serving"
-		}
-
-		if #component == "controller" || #component == "cainjector" {
-			namespace: #config.leaderElection.namespace
-		}
-
-		if #component == "webhook" || #component == "startupapicheck" {
-			namespace: #meta.namespace
-		}
-
-		labels: #meta.labels
-
-		if #meta.annotations != _|_ {
-			annotations: #meta.annotations
+		name:      "\(#meta.name):\(#roleSuffix)"
+		namespace: *#namespace | #config.metadata.namespace
+		labels:    #meta.labels
+		if #config.metadata.annotations != _|_ {
+			annotations: #config.metadata.annotations
 		}
 	}
+}
 
-	if #component == "controller" {
-		rules: [{
-			apiGroups: ["coordination.k8s.io"]
-			resources: ["leases"]
-			resourceNames: ["cert-manager-controller"]
-			verbs: ["get", "update", "patch"]
-		}, {
-			apiGroups: ["coordination.k8s.io"]
-			resources: ["leases"]
-			verbs: ["create"]
-		}]
-	}
+#ControllerRole: #Role & {
+	#config:     cfg.#Config
+	#component:  "controller"
+	#roleSuffix: "leaderelection"
+	#namespace:  #config.leaderElection.namespace
+	rules: [{
+		apiGroups: ["coordination.k8s.io"]
+		resources: ["leases"]
+		resourceNames: ["cert-manager-controller"]
+		verbs: ["get", "update", "patch"]
+	}, {
+		apiGroups: ["coordination.k8s.io"]
+		resources: ["leases"]
+		verbs: ["create"]
+	}]
+}
 
-	if #component == "cainjector" {
-		rules: [{
-			apiGroups: ["coordination.k8s.io"]
-			resources: ["leases"]
-			resourceNames: ["cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core"]
-			verbs: ["get", "update", "patch"]
-		}, {
-			apiGroups: ["coordination.k8s.io"]
-			resources: ["leases"]
-			verbs: ["create"]
-		}]
-	}
+#CaInjectorRole: #Role & {
+	#config:     cfg.#Config
+	#component:  "caInjector"
+	#roleSuffix: "leaderelection"
+	#namespace:  #config.leaderElection.namespace
+	rules: [{
+		apiGroups: ["coordination.k8s.io"]
+		resources: ["leases"]
+		resourceNames: ["cert-manager-cainjector-leader-election", "cert-manager-cainjector-leader-election-core"]
+		verbs: ["get", "update", "patch"]
+	}, {
+		apiGroups: ["coordination.k8s.io"]
+		resources: ["leases"]
+		verbs: ["create"]
+	}]
+}
 
-	if #component == "webhook" {
-		rules: [{
-			apiGroups: [""]
-			resources: ["secrets"]
-			resourceNames: [
-				"\(#meta.name)-ca",
-			]
-			verbs: ["get", "list", "watch", "update"]
-		}, {
-			apiGroups: [""]
-			resources: ["secrets"]
-			verbs: ["create"]
-		}]
-	}
+#StartupApiCheckRole: #Role & {
+	#config:     cfg.#Config
+	#component:  "startupAPICheck"
+	#roleSuffix: "create-cert"
+	rules: [{
+		apiGroups: ["cert-manager.io"]
+		resources: ["certificates"]
+		verbs: ["create"]
+	}]
+}
 
-	if #component == "startupapicheck" {
-		rules: [{
-			apiGroups: ["cert-manager.io"]
-			resources: ["certificates"]
-			verbs: ["create"]
-		}]
-	}
+#WebhookRole: #Role & {
+	#config:     cfg.#Config
+	#component:  "webhook"
+	#roleSuffix: "dynamic-serving"
+	rules: [{
+		apiGroups: [""]
+		resources: ["secrets"]
+		resourceNames: [
+			"\(#config.metadata.name)-\(#component)-ca",
+		]
+		verbs: ["get", "list", "watch", "update"]
+	}, {
+		apiGroups: [""]
+		resources: ["secrets"]
+		verbs: ["create"]
+	}]
 }

--- a/templates/serviceAccount.cue
+++ b/templates/serviceAccount.cue
@@ -1,9 +1,9 @@
 package templates
 
 import (
+	"strings"
 	corev1 "k8s.io/api/core/v1"
 	timoniv1 "timoni.sh/core/v1alpha1"
-
 	cfg "timoni.sh/cert-manager/templates/config"
 )
 
@@ -13,7 +13,7 @@ import (
 
 	#meta: timoniv1.#MetaComponent & {
 		#Meta:      #config.metadata
-		#Component: #component
+		#Component: strings.ToLower(#component)
 	}
 
 	apiVersion: "v1"
@@ -24,51 +24,11 @@ import (
 		imagePullSecrets: #config.imagePullSecrets
 	}
 
-	if #component == "controller" {
-		if #config.controller.serviceAccount.labels != _|_ {
-			metadata: labels: #config.controller.serviceAccount.labels
-		}
-
-		if #config.controller.serviceAccount.annotations != _|_ {
-			metadata: annotations: #config.controller.serviceAccount.annotations
-		}
-
-		automountServiceAccountToken: #config.controller.serviceAccount.automountServiceAccountToken
+	if #config[#component].serviceAccount.labels != _|_ {
+		metadata: labels: #config[#component].serviceAccount.labels
 	}
-
-	if #component == "webhook" {
-		if #config.webhook.serviceAccount.labels != _|_ {
-			metadata: labels: #config.webhook.serviceAccount.labels
-		}
-
-		if #config.webhook.serviceAccount.annotations != _|_ {
-			metadata: annotations: #config.webhook.serviceAccount.annotations
-		}
-
-		automountServiceAccountToken: #config.webhook.serviceAccount.automountServiceAccountToken
+	if #config[#component].serviceAccount.annotations != _|_ {
+		metadata: annotations: #config[#component].serviceAccount.annotations
 	}
-
-	if #component == "cainjector" {
-		if #config.caInjector.serviceAccount.labels != _|_ {
-			metadata: labels: #config.caInjector.serviceAccount.labels
-		}
-
-		if #config.caInjector.serviceAccount.annotations != _|_ {
-			metadata: annotations: #config.caInjector.serviceAccount.annotations
-		}
-
-		automountServiceAccountToken: #config.caInjector.serviceAccount.automountServiceAccountToken
-	}
-
-	if #component == "startupapicheck" {
-		if #config.test.startupAPICheck.serviceAccount.labels != _|_ {
-			metadata: labels: #config.test.startupAPICheck.serviceAccount.labels
-		}
-
-		if #config.test.startupAPICheck.serviceAccount.annotations != _|_ {
-			metadata: annotations: #config.test.startupAPICheck.serviceAccount.annotations
-		}
-
-		automountServiceAccountToken: #config.test.startupAPICheck.serviceAccount.automountServiceAccountToken
-	}
+	automountServiceAccountToken: #config[#component].serviceAccount.automountServiceAccountToken | false
 }


### PR DESCRIPTION
I simplify code by removing `if #component`.

_ServiceAccount_ & _PodDisruptionBudget_ are now generic.

About _Role_ & _RoleBinding_, for me it's preferable to define types as to use conditions.

About deployment, I thinks we can continue to simplify it by moving common spec field to #Deployment 

What do you thinks ?



